### PR TITLE
Composer create-project should run from Docksal

### DIFF
--- a/.docksal/addons/init/init
+++ b/.docksal/addons/init/init
@@ -30,7 +30,7 @@ fin exec composer global require "laravel/installer"
 
 # Install laravel
 cd "$PROJECT_ROOT"
-composer create-project --prefer-dist laravel/laravel "$LARAVEL_ROOT"
+fin exec composer create-project --prefer-dist laravel/laravel "$LARAVEL_ROOT"
 
 echo "Copying Datbase settings..."
 cp "$ADDON_ROOT/config/database.php" "$PROJECT_ROOT/$LARAVEL_ROOT/config/database.php"


### PR DESCRIPTION
When 'composer create-project --prefer-dist laravel/laravel "$LARAVEL_ROOT"' is run it checks for php dependencies from local environment instead of those from Docker. So the build can fail in case if some required php libraries are missing locally. Docksal composer should be used instead.
I have previously reported this issue in https://github.com/docksal/docksal/issues/501